### PR TITLE
srsly 2.4.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "srsly" %}
-{% set version = "2.4.3" %}
-{% set sha256sum = "dbe91f6dd4aea9e819493628356dc715bd9c606486297bb7ca5748e6e003841c" %}
+{% set version = "2.4.5" %}
+{% set sha256sum = "c842258967baa527cea9367986e42b8143a1a890e7d4a18d25a36edc3c7a33c7" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 64450e0..0916b40 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "srsly" %}
-{% set version = "2.4.3" %}
-{% set sha256sum = "dbe91f6dd4aea9e819493628356dc715bd9c606486297bb7ca5748e6e003841c" %}
+{% set version = "2.4.5" %}
+{% set sha256sum = "c842258967baa527cea9367986e42b8143a1a890e7d4a18d25a36edc3c7a33c7" %}
 
 package:
   name: {{ name|lower }}

```

**Jira ticket:** [PKG-467](https://anaconda.atlassian.net/browse/PKG-467) (srsly-2.4.3)

**The upstream data:**
Github releases:  https://github.com/explosion/srsly/releases
[Diff between the latest and previous upstream releases](https://github.com/explosion/srsly/compare/2.4.3...2.4.5)
License: https://github.com/explosion/srsly/blob/master/LICENSE
Requirements:
 * setup.cfg:  https://github.com/explosion/srsly/blob/v2.4.5/setup.cfg
 * setup.py:  https://github.com/explosion/srsly/blob/v2.4.5/setup.py
 *  pyproject.toml:  https://github.com/explosion/srsly/blob/v2.4.5/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Package's statistics**
<details>

 * Priority D | effort: easy | Category: other_key_deps | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.4.5
 * Release on PyPi:
    * version: 2.4.5
    * date: 2022-10-18T09:12:27
* [PyPi history](https://pypi.org/project/srsly/#history)
 * Popularity: 
    * 3 months downloads: 106267.0
    * All time:  1051636 downloads -  srsly  2.4.5  Modern high-performance serialization utilities for Python  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/explosion/srsly/tree/v2.4.5 exists
2. - [x] https://github.com/explosion/srsly is present
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/explosion/srsly/tree/v2.4.5
    200
5. - [ ] Additional research
    https://github.com/explosion/srsly/issues
    200
6. - [x] `dev_url` is present
    https://github.com/explosion/srsly
7. - [x] `doc_url` is present
    https://github.com/explosion/srsly/blob/master/README.md
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE is present
16. - [x] License: MIT
    - [ ] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |

17. - [x] license_family MIT is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/srsly-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/srsly-feedstock/tree/2.4.5)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/srsly)
* [Diff between upstream and feature branch](https://github.com/conda-forge/srsly-feedstock/compare/main...AnacondaRecipes:2.4.5)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/srsly-feedstock/compare/master...AnacondaRecipes:2.4.5)
* [The last merged PRs](https://github.com/AnacondaRecipes/srsly-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.4.5 git@github.com:AnacondaRecipes/srsly-feedstock.git
```


[PKG-467]: https://anaconda.atlassian.net/browse/PKG-467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ