### PR TITLE
srsly 2.4.8: Rebuild for py312

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,5 @@
 aggregate_branch: 3.12
+
+channels:
+    # for catalogue 2.0.10:
+    - https://staging.continuum.io/prefect/fs/catalogue-feedstock/pr4/58d7da2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,1 @@
 aggregate_branch: 3.12
-
-channels:
-    # for catalogue 2.0.10:
-    - https://staging.continuum.io/prefect/fs/catalogue-feedstock/pr4/58d7da2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b24d95a65009c2447e0b49cda043ac53fecf4f09e358d87a57446458f91b8a91
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<36]
 
@@ -35,8 +35,9 @@ test:
     - srsly.tests
   requires:
     - pip
-    - pytest 
-    - mock 
+    - pytest
+    - pytest-timeout >=1.3.3
+    - mock
     - numpy >=1.15.0
     - psutil
   commands:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-3711](https://anaconda.atlassian.net/browse/PKG-3711) 
- [Upstream repository](https://github.com/explosion/srsly/tree/v2.4.8)
- Requirements:
  - https://github.com/explosion/srsly/blob/v2.4.8/pyproject.toml
  - https://github.com/explosion/srsly/blob/v2.4.8/requirements.txt
  - https://github.com/explosion/srsly/blob/v2.4.8/setup.cfg

### Explanation of changes:

- Bump the build number to `1`
- Add `pytest-timeout >=1.3.3` to `test/requires`

### Notes:

- spacy 3.7.2 requires it for py312 https://github.com/AnacondaRecipes/spacy-feedstock/pull/25

[PKG-3711]: https://anaconda.atlassian.net/browse/PKG-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ