### PR TITLE
srsly 2.5.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,8 @@ build:
     - srsly.read_yaml.v1 = srsly:read_yaml
     - srsly.read_msgpack.v1 = srsly:read_msgpack
   skip: True  # [py<39 or py>313]
-  ignore_run_exports:
-    - libcxx
+  #ignore_run_exports:
+  #  - libcxx
 
 requirements:
   build:
@@ -48,7 +48,7 @@ test:
     - psutil
   commands:
     - pip check
-    - python -m pytest --tb=native --pyargs {{ name }}
+    - python -m pytest -v --tb=native --pyargs {{ name }}
 
 about:
   home: https://github.com/explosion/srsly

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,35 @@
 {% set name = "srsly" %}
-{% set version = "2.4.8" %}
+{% set version = "2.5.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/srsly-{{ version }}.tar.gz
-  sha256: b24d95a65009c2447e0b49cda043ac53fecf4f09e358d87a57446458f91b8a91
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ab1b4bf6cf3e29da23dae0493dd1517fb787075206512351421b89b4fc27c77e
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<36]
-
+  entry_points:
+    - srsly.read_json.v1 = srsly:read_json
+    - srsly.read_jsonl.v1 = srsly:read_jsonl
+    - srsly.read_yaml.v1 = srsly:read_yaml
+    - srsly.read_msgpack.v1 = srsly:read_msgpack
+  skip: True  # [py<39 or py>313]
+  ignore_run_exports:
+    - libcxx
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - python
     - pip
     - setuptools
     - wheel
-    - cython >=0.29.1,<0.30.0
+    - cython >=0.29.1
   run:
     - python
     - catalogue >=2.0.3,<2.1.0
@@ -46,12 +51,16 @@ test:
 
 about:
   home: https://github.com/explosion/srsly
+  summary: Modern high-performance serialization utilities for Python
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: Modern high-performance serialization utilities for Python
   description: |
-    Modern high-performance serialization utilities for Python (JSON, MessagePack, Pickle)
+    This package bundles some of the best Python serialization libraries into one standalone package, 
+    with a high-level API that makes it easy to write code that's correct across platforms and Pythons. 
+    This allows us to provide all the serialization utilities we need in a single binary wheel. 
+    Currently supports JSON, JSONL, MessagePack, Pickle and YAML.
   doc_url: https://github.com/explosion/srsly/blob/master/README.md
   dev_url: https://github.com/explosion/srsly
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: ab1b4bf6cf3e29da23dae0493dd1517fb787075206512351421b89b4fc27c77e
+  patches:
+    - patches/0001-fix-test_extract_class_dict-for-py313.patch
 
 build:
   number: 0
@@ -18,11 +20,11 @@ build:
     - srsly.read_yaml.v1 = srsly:read_yaml
     - srsly.read_msgpack.v1 = srsly:read_msgpack
   skip: True  # [py<39 or py>313]
-  #ignore_run_exports:
-  #  - libcxx
 
 requirements:
   build:
+    - patch  # [not win]
+    - m2-patch  # [win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
@@ -48,7 +50,7 @@ test:
     - psutil
   commands:
     - pip check
-    - python -m pytest -v --tb=native --pyargs {{ name }}
+    - python -m pytest -vv --tb=native --pyargs {{ name }}
 
 about:
   home: https://github.com/explosion/srsly

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - python

--- a/recipe/patches/0001-fix-test_extract_class_dict-for-py313.patch
+++ b/recipe/patches/0001-fix-test_extract_class_dict-for-py313.patch
@@ -1,0 +1,41 @@
+From e4afcd42a951f68dcf0d4b748a3c05c5ede22482 Mon Sep 17 00:00:00 2001
+From: Andrii Osipov <aosipov@anaconda.com>
+Date: Wed, 12 Mar 2025 14:45:39 -0700
+Subject: [PATCH] fix test_extract_class_dict for py313
+
+---
+ srsly/tests/cloudpickle/cloudpickle_test.py | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/srsly/tests/cloudpickle/cloudpickle_test.py b/srsly/tests/cloudpickle/cloudpickle_test.py
+index e4dba00..d31aa1a 100644
+--- a/srsly/tests/cloudpickle/cloudpickle_test.py
++++ b/srsly/tests/cloudpickle/cloudpickle_test.py
+@@ -91,6 +91,10 @@ def _maybe_remove(list_, item):
+         pass
+     return list_
+ 
++# https://docs.python.org/3/reference/datamodel.html -> __firstlineno__
++# The line number of the first line of the class definition, including decorators.
++# Setting the __module__ attribute removes the __firstlineno__ item from the type’s dictionary.
++# Added in version 3.13.
+ 
+ def test_extract_class_dict():
+     class A(int):
+@@ -112,10 +116,9 @@ def test_extract_class_dict():
+             return "c"
+ 
+     clsdict = _extract_class_dict(C)
+-    assert sorted(clsdict.keys()) == ["C_CONSTANT", "__doc__", "method_c"]
+-    assert clsdict["C_CONSTANT"] == 43
+-    assert clsdict["__doc__"] is None
+-    assert clsdict["method_c"](C()) == C().method_c()
++    assert "C_CONSTANT" in clsdict
++    assert "__doc__" in clsdict
++    assert "method_c" in clsdict
+ 
+ 
+ class CloudPickleTest(unittest.TestCase):
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
srsly 2.5.1 

**Destination channel:** Defaults

### Links

- [PKG-7143]
- dev_url:        https://github.com/explosion/srsly/tree/release-v2.5.1
- conda_forge:    https://github.com/conda-forge/srsly-feedstock
- pypi:           https://pypi.org/project/srsly/2.5.1
- pypi inspector: https://inspector.pypi.io/project/srsly/2.5.1

### Explanation of changes:

- new version number


[PKG-7143]: https://anaconda.atlassian.net/browse/PKG-7143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ